### PR TITLE
Fix: Prevent saving empty todos during edit

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,9 +34,13 @@ function toggleEditItem(id) {
     todos = todos.map((todo) => {
         if (todo.todoId === id) {
             if (todo.isEditing) {
-            title = document.getElementById(todo.TodoTextId).value;
-            if (title.trim() === "") return;
-            todo.title = title;
+                 const prevTodo = todo.title
+                const title = document.getElementById(todo.TodoTextId).value;
+                if(title.trim() === "") {
+                 todo.title = prevTodo
+                } else {
+                todo.title = title
+                }
             }
             todo.isEditing = !todo.isEditing;
         }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ function toggleEditItem(id) {
     todos = todos.map((todo) => {
         if (todo.todoId === id) {
             if (todo.isEditing) {
-                todo.title = document.getElementById(todo.TodoTextId).value;
+            title = document.getElementById(todo.TodoTextId).value;
+            if (title.trim() === "") return;
+            todo.title = title;
             }
             todo.isEditing = !todo.isEditing;
         }


### PR DESCRIPTION
Resolved an issue where the application would allow saving an empty todo when editing an existing item. Now, the todo will not be updated if the edited content is left empty, ensuring that empty tasks are not saved to the list.